### PR TITLE
fix bug in ElasticSearchSink ,when use IndexnameBuilderContext can't get the right config

### DIFF
--- a/flume-elasticsearch-sink/src/main/java/org/apache/flume/sink/elasticsearch/ElasticSearchSink.java
+++ b/flume-elasticsearch-sink/src/main/java/org/apache/flume/sink/elasticsearch/ElasticSearchSink.java
@@ -320,7 +320,7 @@ public class ElasticSearchSink extends AbstractSink implements Configurable, Bat
     }
 
     Context indexnameBuilderContext = new Context();
-    serializerContext.putAll(
+    indexnameBuilderContext.putAll(
             context.getSubProperties(INDEX_NAME_BUILDER_PREFIX));
 
     try {


### PR DESCRIPTION
fix bug in ElasticSearchSink ,when use IndexnameBuilderContext can't get the right config.
I think the code is to get the config for IndexNameBuilder from Context ，but use the wrong Context“serializerContext”.