### PR TITLE
Solve fastDateFormat unit test failed

### DIFF
--- a/flume-elasticsearch-sink/src/main/java/org/apache/flume/sink/elasticsearch/TimeBasedIndexNameBuilder.java
+++ b/flume-elasticsearch-sink/src/main/java/org/apache/flume/sink/elasticsearch/TimeBasedIndexNameBuilder.java
@@ -42,7 +42,7 @@ public class TimeBasedIndexNameBuilder implements
   public static final String DEFAULT_TIME_ZONE = "Etc/UTC";
 
   private FastDateFormat fastDateFormat = FastDateFormat.getInstance("yyyy-MM-dd",
-      TimeZone.getTimeZone("Etc/UTC"));
+      TimeZone.getTimeZone(DEFAULT_TIME_ZONE));
 
   private String indexPrefix;
 

--- a/flume-elasticsearch-sink/src/test/java/org/apache/flume/sink/elasticsearch/TestElasticSearchIndexRequestBuilderFactory.java
+++ b/flume-elasticsearch-sink/src/test/java/org/apache/flume/sink/elasticsearch/TestElasticSearchIndexRequestBuilderFactory.java
@@ -32,7 +32,9 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Locale;
 import java.util.Map;
+import java.util.TimeZone;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -63,7 +65,10 @@ public class TestElasticSearchIndexRequestBuilderFactory
   @Test
   public void shouldUseUtcAsBasisForDateFormat() {
     assertEquals("Coordinated Universal Time",
-        factory.fastDateFormat.getTimeZone().getDisplayName());
+        factory.fastDateFormat.getTimeZone().getDisplayName(
+                false,
+                TimeZone.LONG,
+                Locale.ENGLISH));
   }
 
   @Test

--- a/flume-elasticsearch-sink/src/test/java/org/apache/flume/sink/elasticsearch/TimeBasedIndexNameBuilderTest.java
+++ b/flume-elasticsearch-sink/src/test/java/org/apache/flume/sink/elasticsearch/TimeBasedIndexNameBuilderTest.java
@@ -25,8 +25,11 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
+import java.util.TimeZone;
 
+import static org.apache.flume.sink.elasticsearch.TimeBasedIndexNameBuilder.DEFAULT_TIME_ZONE;
 import static org.junit.Assert.assertEquals;
 
 public class TimeBasedIndexNameBuilderTest {
@@ -44,7 +47,10 @@ public class TimeBasedIndexNameBuilderTest {
   @Test
   public void shouldUseUtcAsBasisForDateFormat() {
     assertEquals("Coordinated Universal Time",
-            indexNameBuilder.getFastDateFormat().getTimeZone().getDisplayName());
+            indexNameBuilder.getFastDateFormat().getTimeZone().getDisplayName(
+                    false,
+                    TimeZone.LONG,
+                    Locale.ENGLISH));
   }
 
   @Test


### PR DESCRIPTION
Hi, as the title says, fix unit test case failure.

```
org.junit.ComparisonFailure: 
Expected :Coordinated Universal Time
Actual   :协调世界时间
<Click to see difference>


	at org.junit.Assert.assertEquals(Assert.java:117)
	at org.junit.Assert.assertEquals(Assert.java:146)
	at org.apache.flume.sink.elasticsearch.TestElasticSearchIndexRequestBuilderFactory.shouldUseUtcAsBasisForDateFormat(TestElasticSearchIndexRequestBuilderFactory.java:65)
```

